### PR TITLE
feat: добавил поддержку Prometheus для сбора метрик

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,12 +37,18 @@ type EventTypesConfig struct {
 	FollowDeleted string `yaml:"follow_deleted"`
 }
 
+type PrometheusConfig struct {
+	Address string `yaml:"address"`
+	Port    int    `yaml:"port"`
+}
+
 type Config struct {
 	Env        string           `yaml:"env"`
 	GrpcServer GrpcServerConfig `yaml:"grpc_server"`
 	Kafka      KafkaConfig      `yaml:"kafka"`
 	Database   Database         `yaml:"database"`
 	EventTypes EventTypesConfig `yaml:"event_types"`
+	Prometheus PrometheusConfig `yaml:"prometheus"`
 }
 
 type Database struct {
@@ -98,6 +104,10 @@ func MustLoad() *Config {
 	viper.SetDefault("database.db_name", "notificationservice")
 	viper.SetDefault("database.migrations_path", "./migrations")
 
+	// Prometheus defaults
+	viper.SetDefault("prometheus.address", "0.0.0.0")
+	viper.SetDefault("prometheus.port", 9105)
+
 	if err := viper.ReadInConfig(); err != nil {
 		log.Printf("Error reading config file: %s", err)
 		os.Exit(1)
@@ -140,6 +150,10 @@ func MustLoad() *Config {
 		EventTypes: EventTypesConfig{
 			FollowCreated: viper.GetString("event_types.follow_created"),
 			FollowDeleted: viper.GetString("event_types.follow_deleted"),
+		},
+		Prometheus: PrometheusConfig{
+			Address: viper.GetString("prometheus.address"),
+			Port:    viper.GetInt("prometheus.port"),
 		},
 	}
 

--- a/config/example.yml
+++ b/config/example.yml
@@ -35,3 +35,7 @@ database:
   port: "5436"
   db_name: "notificationservice"
   migrations_path: "./migrations"
+
+prometheus:
+  address: "0.0.0.0"
+  port: 9105

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/jackc/pgx/v5 v5.7.5
+	github.com/prometheus/client_golang v1.17.0
 	github.com/soloda1/pinstack-proto-definitions v0.1.17
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
@@ -16,12 +17,15 @@ require (
 )
 
 require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -29,9 +33,13 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.44.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,7 @@ golang.org/x/oauth2 v0.26.0 h1:afQXWNNaeC4nvZ0Ed9XvCCzXM6UHJG7iCg0W4fPqSBE=
 golang.org/x/oauth2 v0.26.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
This pull request introduces Prometheus metrics integration into the notification service, enabling monitoring and observability. Key changes include adding Prometheus configuration, setting up a metrics server, and updating dependencies.

### Prometheus Integration

* **Metrics Server Setup**: Added a Prometheus metrics server in `cmd/server/main.go`. This includes initializing the server, handling `/metrics` requests, and ensuring graceful shutdown during application termination. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR5-R10) [[2]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR60-L76) [[3]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR107-R124)
* **Configuration Updates**: Introduced a new `PrometheusConfig` structure in `config/config.go` to manage Prometheus settings (`address` and `port`). Updated the `MustLoad` function to load these settings with defaults. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R40-R51) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R107-R110) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R154-R157)
* **Example Configuration**: Updated `config/example.yml` to include Prometheus configuration examples for `address` and `port`.

### Dependency Updates

* **Prometheus Client Library**: Added `github.com/prometheus/client_golang` as a direct dependency in `go.mod`. Included related indirect dependencies required for Prometheus functionality (e.g., `github.com/prometheus/common`, `github.com/prometheus/procfs`). [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R11) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R20-R42)