### PR TITLE
fix: update Makefile and CI configuration for local quick tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
 
     - name: Start Full Infrastructure for Integration Tests
       working-directory: pinstack-system-tests
+      env:
+        NOTIFICATION_SERVICE_CONTEXT: ../
       run: |
         # Запускаем все необходимые контейнеры для интеграционных тестов
         docker compose -f docker-compose.test.yml up -d \


### PR DESCRIPTION
This pull request introduces improvements to the integration testing workflow for the notification service, focusing on enabling quick local test runs and ensuring proper environment setup. The most important changes are grouped below:

**Integration Test Infrastructure Improvements:**

* Added the `NOTIFICATION_SERVICE_CONTEXT` environment variable when starting the full infrastructure for integration tests in `.github/workflows/ci.yml` to ensure the notification service context is correctly set.
* Updated the `Makefile` to set the `NOTIFICATION_SERVICE_CONTEXT` environment variable when starting notification infrastructure, ensuring the correct path is used for local integration tests.

**New Quick Local Test Target:**

* Introduced a new `quick-test-local` target in the `Makefile` for fast local integration testing with the notification service, including service startup, readiness checks, and test execution.
* Added `quick-test-local` to the `.PHONY` targets in the `Makefile` for proper makefile behavior.