### PR TITLE
feat: add metrics provider to gRPC server for enhanced monitoring cap…

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	notificationGRPCApi := notification_grpc.NewNotificationGRPCService(notificationService, log)
-	grpcServer := notification_grpc.NewServer(notificationGRPCApi, cfg.GrpcServer.Address, cfg.GrpcServer.Port, log)
+	grpcServer := notification_grpc.NewServer(notificationGRPCApi, cfg.GrpcServer.Address, cfg.GrpcServer.Port, log, metricsProvider)
 
 	metricsServer := metrics_server.NewMetricsServer(cfg.Prometheus.Address, cfg.Prometheus.Port, log)
 

--- a/internal/infrastructure/inbound/grpc/server.go
+++ b/internal/infrastructure/inbound/grpc/server.go
@@ -23,14 +23,16 @@ type Server struct {
 	address                 string
 	port                    int
 	log                     ports.Logger
+	metrics                 ports.MetricsProvider
 }
 
-func NewServer(grpcService *NotificationGRPCService, address string, port int, log ports.Logger) *Server {
+func NewServer(grpcService *NotificationGRPCService, address string, port int, log ports.Logger, metrics ports.MetricsProvider) *Server {
 	return &Server{
 		notificationGRPCService: grpcService,
 		address:                 address,
 		port:                    port,
 		log:                     log,
+		metrics:                 metrics,
 	}
 }
 
@@ -51,6 +53,7 @@ func (s *Server) Run() error {
 	s.server = grpc.NewServer(
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			middleware.UnaryLoggerInterceptor(s.log),
+			middleware.UnaryMetricsInterceptor(s.metrics),
 			grpc_recovery.UnaryServerInterceptor(opts...),
 		)),
 	)


### PR DESCRIPTION
This pull request introduces metrics collection to the gRPC server by integrating a metrics provider and adding a metrics interceptor. The changes ensure that the server can track and expose relevant metrics for observability.

Metrics integration:

* Added a `metrics` field to the `Server` struct in `server.go` and updated the constructor to accept a `MetricsProvider` instance, enabling metrics support in the gRPC server.
* Modified the gRPC server initialization in `main.go` to pass the `metricsProvider` when creating the server, ensuring metrics functionality is available at startup.

Middleware enhancement:

* Added the `UnaryMetricsInterceptor` to the gRPC middleware chain in the `Run` method, allowing metrics to be collected for each unary gRPC request.…abilities